### PR TITLE
Add remote job option

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/IBM_zOS_Connector/SCLMSCMRevisionState.java
+++ b/src/main/java/org/jenkinsci/plugins/IBM_zOS_Connector/SCLMSCMRevisionState.java
@@ -78,7 +78,7 @@ public class SCLMSCMRevisionState extends SCMRevisionState {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         // Submit the job for the DBUTIL report and build remote file list.
-        if (ZFTPConnector.submit(inputStream, true, 0, outputStream, true)) {
+        if (ZFTPConnector.submit(null, inputStream, true, 0, outputStream, true, false)) {
             String out = "";
             try {
                 out = outputStream.toString("UTF-8");

--- a/src/main/java/org/jenkinsci/plugins/IBM_zOS_Connector/ZFTPConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/IBM_zOS_Connector/ZFTPConnector.java
@@ -14,632 +14,701 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-
 /**
- * <h1>ZFTPConnector</h1>
- * FTP-based communication with z/OS-like systems.
- * Used for submitting jobs, fetching job log and extraction of MaxCC.
+ * <h1>ZFTPConnector</h1> FTP-based communication with z/OS-like systems. Used
+ * for submitting jobs, fetching job log and extraction of MaxCC.
  *
  * @author <a href="mailto:candiduslynx@gmail.com">Alexander Shcherbakov</a>
  * @version 1.0
  */
 class ZFTPConnector {
-    // Server info.
-    /**
-     * Will ask LPAR once in 10 seconds.
-     */
-    private static final long waitInterval = 10 * 1000;
-    /**
-     * Pattern for search of jobName
-     */
-    private static final Pattern JesJobName = Pattern.compile("250-It is known to JES as (.*)");
+	// Server info.
+	/**
+	 * Will ask LPAR once in 10 seconds.
+	 */
+	private static final long waitInterval = 10 * 1000;
+	/**
+	 * Pattern for search of jobName
+	 */
+	private static final Pattern JesJobName = Pattern.compile("250-It is known to JES as (.*)");
 
-    // Credentials.
-    /**
-     * Simple logger.
-     */
-    private static final Logger logger = Logger.getLogger(ZFTPConnector.class.getName());
-    /**
-     * LPAR name or IP to connect to.
-     */
-    private String server;
+	// Credentials.
+	/**
+	 * Simple logger.
+	 */
+	private static final Logger logger = Logger.getLogger(ZFTPConnector.class.getName());
+	/**
+	 * LPAR name or IP to connect to.
+	 */
+	private String server;
 
-    // Wait parameters.
-    /**
-     * FTP port for connection
-     */
-    private int port;
+	// Wait parameters.
+	/**
+	 * FTP port for connection
+	 */
+	private int port;
 
-    // Job info from JES-like system.
-    /**
-     * UserID.
-     */
-    private String userID;
-    /**
-     * User password.
-     */
-    private String password;
-    /**
-     * Time to wait before giving up in milliseconds. If set to <code>0</code> will wait forever.
-     */
-    private long waitTime;
-    /**
-     * JobID in JES.
-     */
-    private String jobID;
-    /**
-     * Whether job log was successfully captured
-     */
-    private boolean jobLogCaptured;
+	// Job info from JES-like system.
+	/**
+	 * UserID.
+	 */
+	private String userID;
+	/**
+	 * User password.
+	 */
+	private String password;
+	/**
+	 * Time to wait before giving up in milliseconds. If set to <code>0</code> will
+	 * wait forever.
+	 */
+	private long waitTime;
+	/**
+	 * JobID in JES.
+	 */
+	private String jobID;
+	/**
+	 * Whether job log was successfully captured
+	 */
+	private boolean jobLogCaptured;
 
-    // Work elements.
-    /**
-     * Jobname in JES.
-     */
-    private String jobName;
-    /**
-     * Job's MaxCC.
-     */
-    private String jobCC;
-    // JESINTERFACELEVEL=1
-    private boolean JESINTERFACELEVEL1;
-    /**
-     * FTPClient from <i>Apache Commons-Net</i>. Used for FTP communication.
-     */
-    private FTPClient FTPClient;
-    /**
-     * Log prefix (default: "ZFTPConnector")
-     */
-    private String logPrefix;
-    /**
-     * Task listener (if provided).
-     */
-    private TaskListener listener;
-    /**
-     * FTP transfer mode
-     */
-    private boolean FTPActiveMode;
+	// Work elements.
+	/**
+	 * Jobname in JES.
+	 */
+	private String jobName;
+	/**
+	 * Job's MaxCC.
+	 */
+	private String jobCC;
+	// JESINTERFACELEVEL=1
+	private boolean JESINTERFACELEVEL1;
+	/**
+	 * FTPClient from <i>Apache Commons-Net</i>. Used for FTP communication.
+	 */
+	private FTPClient FTPClient;
+	/**
+	 * Log prefix (default: "ZFTPConnector")
+	 */
+	private String logPrefix;
+	/**
+	 * Task listener (if provided).
+	 */
+	private TaskListener listener;
+	/**
+	 * FTP transfer mode
+	 */
+	private boolean FTPActiveMode;
 
-    /**
-     * Basic constructor with minimal parameters required.
-     *
-     * @param server             LPAR name or IP address to connect to.
-     * @param port               LPAR password.
-     * @param userID             UserID.
-     * @param password           User password.
-     * @param JESINTERFACELEVEL1 Is FTP server configured for JESINTERFACELEVEL=1?
-     * @param logPrefix          Log prefix.
-     * @param FTPActiveMode      FTP data transfer mode (true=active, false=passive) 
-     */
-    ZFTPConnector(String server, int port, String userID, String password, boolean JESINTERFACELEVEL1, String logPrefix, boolean FTPActiveMode) {
-        // Copy values
-        this.server = server;
-        this.port = port;
-        this.userID = userID;
-        this.password = password;
-        this.JESINTERFACELEVEL1 = JESINTERFACELEVEL1;
-        this.FTPActiveMode = FTPActiveMode; 
+	/**
+	 * Basic constructor with minimal parameters required.
+	 *
+	 * @param server             LPAR name or IP address to connect to.
+	 * @param port               LPAR password.
+	 * @param userID             UserID.
+	 * @param password           User password.
+	 * @param JESINTERFACELEVEL1 Is FTP server configured for JESINTERFACELEVEL=1?
+	 * @param logPrefix          Log prefix.
+	 * @param FTPActiveMode      FTP data transfer mode (true=active, false=passive)
+	 */
+	ZFTPConnector(String server, int port, String userID, String password, boolean JESINTERFACELEVEL1, String logPrefix,
+			boolean FTPActiveMode) {
+		// Copy values
+		this.server = server;
+		this.port = port;
+		this.userID = userID;
+		this.password = password;
+		this.JESINTERFACELEVEL1 = JESINTERFACELEVEL1;
+		this.FTPActiveMode = FTPActiveMode;
 
-        this.FTPClient = null;
+		this.FTPClient = null;
 
-        this.logPrefix = "";
-        if (logPrefix != null)
-            this.logPrefix = logPrefix;
-        this.log("Created ZFTPConnector");
+		this.logPrefix = "";
+		if (logPrefix != null)
+			this.logPrefix = logPrefix;
+		this.log("Created ZFTPConnector");
 
-        this.listener = null;
-    }
+		this.listener = null;
+	}
 
-    /**
-     * Try to connect to the <b><code>server</code></b> using the parameters passed to the constructor.
-     *
-     * @return Whether the connection was established using the parameters passed to the constructor.
-     * @see ZFTPConnector#ZFTPConnector(String, int, String, String, boolean, String)
-     */
-    private boolean connect() {
-        // 1. Disconnect and ignore error.
-        try {
-            this.FTPClient.disconnect();
-        } catch (IOException ignored) {
+	/**
+	 * Try to connect to the <b><code>server</code></b> using the parameters passed
+	 * to the constructor.
+	 *
+	 * @return Whether the connection was established using the parameters passed to
+	 *         the constructor.
+	 * @see ZFTPConnector#ZFTPConnector(String, int, String, String, boolean,
+	 *      String)
+	 */
+	private boolean connect() {
+		// 1. Disconnect and ignore error.
+		try {
+			this.FTPClient.disconnect();
+		} catch (IOException ignored) {
 
-        }
-        // Perform the connection.
-        try {
-            int reply; // Temp value to contain server response.
+		}
+		// Perform the connection.
+		try {
+			int reply; // Temp value to contain server response.
 
-            // Try to connect.
-            this.FTPClient.connect(this.server, this.port);
+			// Try to connect.
+			this.FTPClient.connect(this.server, this.port);
 
-            // After connection attempt, check the reply code to verify success.
-            reply = this.FTPClient.getReplyCode();
-            if (!FTPReply.isPositiveCompletion(reply)) {
-                // Bad reply code.
-                this.FTPClient.disconnect(); // Disconnect from LPAR.
-                this.err("FTP server refused connection."); // Print error.
-                return false; // Finish with failure.
-            }
-            this.log("FTP: connected to " + server + ":" + port);
-        }
-        // IOException handling
-        catch (IOException e) {
-            // Close the connection if it's still open.
-            if (this.FTPClient.isConnected()) {
-                try {
-                    this.FTPClient.disconnect();
-                } catch (IOException f) {
-                    // Do nothing
-                }
-            }
-            this.err("Could not connect to server.");
-            e.printStackTrace();
-            return false;
-        }
-        // Finally, return with success.
-        return true;
-    }
+			// After connection attempt, check the reply code to verify success.
+			reply = this.FTPClient.getReplyCode();
+			if (!FTPReply.isPositiveCompletion(reply)) {
+				// Bad reply code.
+				this.FTPClient.disconnect(); // Disconnect from LPAR.
+				this.err("FTP server refused connection."); // Print error.
+				return false; // Finish with failure.
+			}
+			this.log("FTP: connected to " + server + ":" + port);
+		}
+		// IOException handling
+		catch (IOException e) {
+			// Close the connection if it's still open.
+			if (this.FTPClient.isConnected()) {
+				try {
+					this.FTPClient.disconnect();
+				} catch (IOException f) {
+					// Do nothing
+				}
+			}
+			this.err("Could not connect to server.");
+			e.printStackTrace();
+			return false;
+		}
+		// Finally, return with success.
+		return true;
+	}
 
-    /**
-     * Try to logon to the <b><code>server</code></b> using the parameters passed to the constructor.
-     * Also, <code>site filetype=jes jesjobname=* jesowner=*</code> command is invoked.
-     *
-     * @return Whether the credentials supplied are valid and the connection was established.
-     * @see ZFTPConnector#ZFTPConnector(String, int, String, String, boolean, String)
-     * @see ZFTPConnector#connect()
-     */
-    private boolean logon() {
-        // 1. log out, ignore error
-        try {
-            this.FTPClient.logout();
-        } catch (IOException ignored) {
-        }
+	/**
+	 * Try to logon to the <b><code>server</code></b> using the parameters passed to
+	 * the constructor. Also, <code>site filetype=jes jesjobname=* jesowner=*</code>
+	 * command is invoked.
+	 *
+	 * @return Whether the credentials supplied are valid and the connection was
+	 *         established.
+	 * @see ZFTPConnector#ZFTPConnector(String, int, String, String, boolean,
+	 *      String)
+	 * @see ZFTPConnector#connect()
+	 */
+	private boolean logon() {
+		// 1. log out, ignore error
+		try {
+			this.FTPClient.logout();
+		} catch (IOException ignored) {
+		}
 
-        // Check whether we are already connected. If not, try to reconnect.
-        if (!this.connect())
-            return false; // Couldn't connect to the server. Can't check the credentials.
+		// Check whether we are already connected. If not, try to reconnect.
+		if (!this.connect())
+			return false; // Couldn't connect to the server. Can't check the credentials.
 
-        // Perform the login process.
-        try {
-            int reply; // Temp value for server reply code.
+		// Perform the login process.
+		try {
+			int reply; // Temp value for server reply code.
 
-            // Try to login.
-            if (!this.FTPClient.login(this.userID, this.password)) {
-                // If couldn't login, we should logout and return failure.
-                this.FTPClient.logout();
-                return false;
-            }
+			// Try to login.
+			if (!this.FTPClient.login(this.userID, this.password)) {
+				// If couldn't login, we should logout and return failure.
+				this.FTPClient.logout();
+				return false;
+			}
 
-            // Try to set filetype, jesjobname and jesstatus.
-            this.FTPClient.site("filetype=jes jesjobname=* jesstatus=ALL");
-            // Check reply.
-            reply = this.FTPClient.getReplyCode();
-            if (!FTPReply.isPositiveCompletion(reply)) {
-                this.FTPClient.disconnect();
-                this.err("FTP server refused to change FileType and JESJobName.");
-                return false;
-            }
-        } catch (IOException e) {
-            if (this.FTPClient.isConnected()) {
-                try {
-                    this.FTPClient.disconnect();
-                } catch (IOException f) {
-                    // do nothing
-                }
-            }
-            this.err("Could not logon to server.");
-            e.printStackTrace();
-            return false;
-        }
+			// Try to set filetype, jesjobname and jesstatus.
+			this.FTPClient.site("filetype=jes jesjobname=* jesstatus=ALL");
+			// Check reply.
+			reply = this.FTPClient.getReplyCode();
+			if (!FTPReply.isPositiveCompletion(reply)) {
+				this.FTPClient.disconnect();
+				this.err("FTP server refused to change FileType and JESJobName.");
+				return false;
+			}
+		} catch (IOException e) {
+			if (this.FTPClient.isConnected()) {
+				try {
+					this.FTPClient.disconnect();
+				} catch (IOException f) {
+					// do nothing
+				}
+			}
+			this.err("Could not logon to server.");
+			e.printStackTrace();
+			return false;
+		}
 
-        // If go here, everything went fine.
-        return true;
-    }
+		// If go here, everything went fine.
+		return true;
+	}
 
-    /**
-     * Try logging out of the FTP server.
-     * This will not fail at all - instead if the next relogon attempt fails you will see something more accurate.
-     */
-    private void disconnect() {
-        if (this.FTPClient == null)
-            return;
-        try {
-            this.FTPClient.logout();
-        } catch (IOException ignored) {
-        } finally {
-            try {
-                this.FTPClient.disconnect();
-            } catch (IOException ignored) {
-            }
-        }
-    }
+	/**
+	 * Try logging out of the FTP server. This will not fail at all - instead if the
+	 * next relogon attempt fails you will see something more accurate.
+	 */
+	private void disconnect() {
+		if (this.FTPClient == null)
+			return;
+		try {
+			this.FTPClient.logout();
+		} catch (IOException ignored) {
+		} finally {
+			try {
+				this.FTPClient.disconnect();
+			} catch (IOException ignored) {
+			}
+		}
+	}
 
-    boolean submit(InputStream inputStream, boolean wait, int waitTime, OutputStream outputStream, boolean deleteLogFromSpool, TaskListener taskListener) {
-        this.listener = taskListener;
-        return this.submit(inputStream, wait, waitTime, outputStream, deleteLogFromSpool);
-    }
+	boolean submit(String remoteJobName, InputStream inputStream, boolean wait, int waitTime, OutputStream outputStream,
+			boolean deleteLogFromSpool, TaskListener taskListener, boolean isJobOnHost) {
+		this.listener = taskListener;
+		return this.submit(remoteJobName, inputStream, wait, waitTime, outputStream, deleteLogFromSpool, isJobOnHost);
+	}
 
-    /**
-     * Submit job for execution.
-     *
-     * @param inputStream        JCL text of the job.
-     * @param wait               Whether we need for the job to complete.
-     * @param waitTime           Maximum wait time in minutes. If set to <code>0</code>, will wait forever.
-     * @param outputStream       Stream to put job log. Can be <code>Null</code>.
-     * @param deleteLogFromSpool Whether the job log should be deleted fro spool upon job end.
-     * @return Whether the job was successfully submitted and the job log was fetched.
-     * <br><b><code>jobCC</code></b> holds the response of the operation (including errors).
-     * @see ZFTPConnector#logon()
-     * @see ZFTPConnector#waitForCompletion(OutputStream)
-     * @see ZFTPConnector#deleteJobLog()
-     */
-    boolean submit(InputStream inputStream, boolean wait, int waitTime, OutputStream outputStream, boolean deleteLogFromSpool) {
-        this.waitTime = ((long) waitTime) * 60 * 1000; // Minutes to milliseconds.
+	/**
+	 * Submit job for execution.
+	 *
+	 * @param remoteJobName      JCL file for remote job.
+	 * @param inputStream        JCL text of the job.
+	 * @param wait               Whether we need for the job to complete.
+	 * @param waitTime           Maximum wait time in minutes. If set to
+	 *                           <code>0</code>, will wait forever.
+	 * @param outputStream       Stream to put job log. Can be <code>Null</code>.
+	 * @param deleteLogFromSpool Whether the job log should be deleted from spool
+	 *                           upon job end.
+	 * @param isJobOnHost        Whether job file resides on remote (z/OS) or local
+	 *                           (Jenkins) system
+	 * @return Whether the job was successfully submitted and the job log was
+	 *         fetched. <br>
+	 *         <b><code>jobCC</code></b> holds the response of the operation
+	 *         (including errors).
+	 * @see ZFTPConnector#logon()
+	 * @see ZFTPConnector#waitForCompletion(OutputStream)
+	 * @see ZFTPConnector#deleteJobLog()
+	 */
+	boolean submit(String remoteJobFile, InputStream inputStream, boolean wait, int waitTime, OutputStream outputStream,
+			boolean deleteLogFromSpool, boolean isJobOnHost) {
+		this.waitTime = ((long) waitTime) * 60 * 1000; // Minutes to milliseconds.
 
-        // Clean-up
-        this.jobID = "";
-        this.jobName = "";
-        this.jobCC = "";
-        this.jobLogCaptured = false;
+		// Clean-up
+		this.jobID = "";
+		this.jobName = "";
+		this.jobCC = "";
+		this.jobLogCaptured = false;
 
-        // Create FTPClient
-        this.FTPClient = new FTPClient();
-        // Make password invisible from log
-        this.FTPClient.addProtocolCommandListener(new PrintCommandListener(new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8)), true));
+		// Add quotes to z/OS dataset name if missing
+		if (remoteJobFile != null && !remoteJobFile.isEmpty()) {
+			if (!remoteJobFile.startsWith("'")) {
+				remoteJobFile = "'" + remoteJobFile;
+			}
+			if (!remoteJobFile.endsWith("'")) {
+				remoteJobFile = remoteJobFile + "'";
+			}
+		}
+		// Create FTPClient
+		this.FTPClient = new FTPClient();
+		// Make password invisible from log
+		this.FTPClient.addProtocolCommandListener(new PrintCommandListener(
+				new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8)), true));
 
+		// Verify connection.
+		if (!this.logon()) {
+			this.disconnect();
+			this.jobCC = "COULD_NOT_CONNECT";
+			return false;
+		}
 
-        // Verify connection.
-        if (!this.logon()) {
-            this.disconnect();
-            this.jobCC = "COULD_NOT_CONNECT";
-            return false;
-        }
+		try {
+			if (!this.FTPActiveMode) {
+				this.FTPClient.enterLocalPassiveMode();
+			}
+			// Submit the job either remote or locally
+			if (!isJobOnHost) {
+				this.FTPClient.storeFile("jenkins.sub", inputStream);
+			} else {
+				// Remote job call always waits for completion, joblog is put to outputStream
+				this.log("Submit remote job " + remoteJobFile);
+				boolean result = this.FTPClient.retrieveFile(remoteJobFile, outputStream);
+				if (result && (FTPClient.getReplyCode() == 250) && !outputStream.toString().isEmpty()) {
+					this.jobLogCaptured = true;
+					String joblog = outputStream.toString();
+					for (String line : joblog.split("\\n")) {
+						if (line.contains("JOB FAILED - JCL ERROR")) {
+							jobCC = "JCL_ERROR";
+						}
+						int index = line.indexOf("$HASP395");
+						if (index != -1) {
+							String[] words = (line.split("(\\s+)"));
+							jobID = words[2];
+							jobName = words[4];
+							if (!jobCC.equals("JCL_ERROR")) {
+								words = words[7].split("=");
+								if (words[0].equals("ABEND")) {
+									jobCC = "ABEND_";
+								}
+								jobCC = jobCC + words[1];
+							}
+							break;
+						}
+					}
+					if (deleteLogFromSpool) {
+						this.deleteJobLog();
+					}
+					this.disconnect();
+					return true;
+				} else {
+					this.jobCC = "REMOTE_JOB_EXECUTION_FAILED";
+					this.err("Execution of remote job failed. Response lines:---->\\n");
+					Arrays.stream(this.FTPClient.getReplyStrings()).forEachOrdered(this::err);
+					this.err("Execution of remote job failed. Response lines:---->\\n");
+					return false;
+				}
+			}
 
-        try {
-            // Submit the job.
-        	if (!this.FTPActiveMode) {
-        		this.FTPClient.enterLocalPassiveMode();
-        	}
-            this.FTPClient.storeFile("jenkins.sub", inputStream);
+			// Scan reply from server to get JobID.
+			for (String s : this.FTPClient.getReplyStrings()) {
+				Matcher matcher = JesJobName.matcher(s);
+				if (matcher.matches()) {
+					// Set jobID
+					this.jobID = matcher.group(1);
+					break;
+				}
+			}
+			if (this.jobID.isEmpty()) {
+				this.err("Failed to parse JES job ID. Response lines:---->\n");
+				Arrays.stream(this.FTPClient.getReplyStrings()).forEachOrdered(this::err);
+				this.err("Failed to parse JES job ID. Response lines:<----\n");
+				this.jobCC = "FAILED_TO_PARSE_JOB_ID";
+				return false;
+			}
+			this.log("Submitted job [" + this.jobID + "]");
+			inputStream.close();
+		} catch (FTPConnectionClosedException e) {
+			this.err("Server closed connection.");
+			e.printStackTrace();
+			this.jobCC = "SERVER_CLOSED_CONNECTION";
+			return false;
+		} catch (IOException e) {
+			e.printStackTrace();
+			this.jobCC = "IO_ERROR";
+			return false;
+		}
 
-            // Scan reply from server to get JobID.
-            for (String s : this.FTPClient.getReplyStrings()) {
-                Matcher matcher = JesJobName.matcher(s);
-                if (matcher.matches()) {
-                    // Set jobID
-                    this.jobID = matcher.group(1);
-                    break;
-                }
-            }
-            if (this.jobID.isEmpty()) {
-                this.err("Failed to parse JES job ID. Response lines:---->\n");
-                Arrays.stream(this.FTPClient.getReplyStrings()).forEachOrdered(this::err);
-                this.err("Failed to parse JES job ID. Response lines:<----\n");
-                this.jobCC = "FAILED_TO_PARSE_JOB_ID";
-                return false;
-            }
-            this.log("Submitted job [" + this.jobID + "]");
-            inputStream.close();
-        } catch (FTPConnectionClosedException e) {
-            this.err("Server closed connection.");
-            e.printStackTrace();
-            this.jobCC = "SERVER_CLOSED_CONNECTION";
-            return false;
-        } catch (IOException e) {
-            e.printStackTrace();
-            this.jobCC = "IO_ERROR";
-            return false;
-        }
+		if (wait) {
+			// Wait for completion.
+			if (this.waitForCompletion(outputStream)) {
+				if (deleteLogFromSpool) {
+					// Delete job log from spool.
+					this.deleteJobLog();
+				}
+				this.disconnect();
+				return true;
+			} else {
+				if (this.jobCC == null)
+					this.jobCC = "JOB_DID_NOT_FINISH_IN_TIME";
+				this.disconnect();
+				return false;
+			}
+		}
 
-        if (wait) {
-            // Wait for completion.
-            if (this.waitForCompletion(outputStream)) {
-                if (deleteLogFromSpool) {
-                    // Delete job log from spool.
-                    this.deleteJobLog();
-                }
-                this.disconnect();
-                return true;
-            } else {
-                if (this.jobCC == null)
-                    this.jobCC = "JOB_DID_NOT_FINISH_IN_TIME";
-                this.disconnect();
-                return false;
-            }
-        }
+		// If we are here, everything went fine for local job.
+		this.disconnect();
+		return true;
+	}
 
-        // If we are here, everything went fine.
-        this.disconnect();
-        return true;
-    }
+	/**
+	 * Wait for he completion of the job.
+	 *
+	 * @param outputStream Stream to hold job log.
+	 * @return Whether the job finished in time.
+	 * @see ZFTPConnector#submit(InputStream, boolean, int, OutputStream, boolean)
+	 * @see ZFTPConnector#fetchJobLog(OutputStream)
+	 */
+	private boolean waitForCompletion(OutputStream outputStream) {
+		// Initialize current time and estimated time.
+		long curr = System.currentTimeMillis();
+		long jobEndTime = curr + this.waitTime;
+		boolean eternal = (waitTime == 0);
+		boolean jobWasObserved = false;
 
-    /**
-     * Wait for he completion of the job.
-     *
-     * @param outputStream Stream to hold job log.
-     * @return Whether the job finished in time.
-     * @see ZFTPConnector#submit(InputStream, boolean, int, OutputStream, boolean)
-     * @see ZFTPConnector#fetchJobLog(OutputStream)
-     */
-    private boolean waitForCompletion(OutputStream outputStream) {
-        // Initialize current time and estimated time.
-        long curr = System.currentTimeMillis();
-        long jobEndTime = curr + this.waitTime;
-        boolean eternal = (waitTime == 0);
-        boolean jobWasObserved = false;
+		// Perform wait
+		do {
+			// Wait
+			try {
+				Thread.sleep(waitInterval);
+				curr = System.currentTimeMillis();
+			} catch (InterruptedException e) {
+				this.err("Interrupted.");
+				this.jobCC = "WAIT_INTERRUPTED";
+				return false;
+			}
 
-        // Perform wait
-        do {
-            // Wait
-            try {
-                Thread.sleep(waitInterval);
-                curr = System.currentTimeMillis();
-            } catch (InterruptedException e) {
-                this.err("Interrupted.");
-                this.jobCC = "WAIT_INTERRUPTED";
-                return false;
-            }
+			// check job state
+			if (this.checkJobAvailability()) {
+				jobWasObserved = true;
+			} else {
+				if (jobWasObserved) {
+					return false;
+				}
+			}
+			// Try to fetch job log.
+			if (this.fetchJobLog(outputStream))
+				return true;
+		} while (eternal || (curr <= jobEndTime));
 
-            // check job state
-            if (this.checkJobAvailability()) {
-                jobWasObserved = true;
-            } else {
-                if (jobWasObserved) {
-                    return false;
-                }
-            }
-            // Try to fetch job log.
-            if (this.fetchJobLog(outputStream))
-                return true;
-        } while (eternal || (curr <= jobEndTime));
+		// Exit with wait error.
+		this.jobCC = "WAIT_ERROR";
+		return false;
+	}
 
-        // Exit with wait error.
-        this.jobCC = "WAIT_ERROR";
-        return false;
-    }
+	/**
+	 * @return true if job can be listed through FTP.
+	 */
+	private boolean checkJobAvailability() {
+		if (!this.FTPActiveMode) {
+			this.FTPClient.enterLocalPassiveMode();
+		}
+		// Verify connection.
+		if (!this.logon()) {
+			this.jobCC = "CHECK_JOB_AVAILABILITY_ERROR_LOGIN";
+			return false;
+		}
 
-    /**
-     * @return true if job can be listed through FTP.
-     */
-    private boolean checkJobAvailability() {
-    	if (!this.FTPActiveMode) {
-    		this.FTPClient.enterLocalPassiveMode();
-    	}
-        // Verify connection.
-        if (!this.logon()) {
-            this.jobCC = "CHECK_JOB_AVAILABILITY_ERROR_LOGIN";
-            return false;
-        }
+		// Try listing files
+		try {
+			String[] availableJobs = this.FTPClient.listNames("*");
+			if (availableJobs == null) {
+				this.err("failed to list available jobs");
+				return false;
+			}
+			if (Arrays.stream(availableJobs).anyMatch(name -> this.jobID.equals(name))) {
+				return true;
+			}
+			this.err("Job [" + this.jobID + "] cannot be found in JES");
+			this.jobCC = "JOB_NOT_FOUND_IN_JES";
+			return false;
+		} catch (IOException e) {
+			this.jobCC = "CHECK_JOB_AVAILABILITY_IO_ERROR";
+			return false;
+		}
+	}
 
-        // Try listing files
-        try {
-            String[] availableJobs = this.FTPClient.listNames("*");
-            if (availableJobs == null) {
-                this.err("failed to list available jobs");
-                return false;
-            }
-            if (Arrays.stream(availableJobs).anyMatch(name -> this.jobID.equals(name))) {
-                return true;
-            }
-            this.err("Job [" + this.jobID + "] cannot be found in JES");
-            this.jobCC = "JOB_NOT_FOUND_IN_JES";
-            return false;
-        } catch (IOException e) {
-            this.jobCC = "CHECK_JOB_AVAILABILITY_IO_ERROR";
-            return false;
-        }
-    }
+	/**
+	 * Fetch job log from spool.
+	 *
+	 * @param outputStream Stream to hold the job log.
+	 * @return Whether the job log was fetched from the LPAR.
+	 * @see ZFTPConnector#waitForCompletion(OutputStream)
+	 */
+	private boolean fetchJobLog(OutputStream outputStream) {
+		// Verify connection.
+		if (!this.logon()) {
+			this.jobCC = "FETCH_LOG_ERROR_LOGIN";
+			return false;
+		}
 
-    /**
-     * Fetch job log from spool.
-     *
-     * @param outputStream Stream to hold the job log.
-     * @return Whether the job log was fetched from the LPAR.
-     * @see ZFTPConnector#waitForCompletion(OutputStream)
-     */
-    private boolean fetchJobLog(OutputStream outputStream) {
-        // Verify connection.
-        if (!this.logon()) {
-            this.jobCC = "FETCH_LOG_ERROR_LOGIN";
-            return false;
-        }
+		if (!this.FTPActiveMode) {
+			this.FTPClient.enterLocalPassiveMode();
+		}
+		if (!this.jobLogCaptured) {
+			// Try fetching.
+			try {
+				// Try fetching the log.
+				this.jobLogCaptured = this.FTPClient.retrieveFile(this.jobID, outputStream);
+				if (!this.jobLogCaptured) {
+					this.jobCC = "RETR_ERR_JOB_NOT_FINISHED_OR_NOT_FOUND";
+					return false;
+				}
+			} catch (IOException e) {
+				this.jobCC = "FETCH_LOG_IO_ERROR";
+				return false;
+			}
+		}
+		return this.obtainJobRC();
+	}
 
-    	if (!this.FTPActiveMode) {
-    		this.FTPClient.enterLocalPassiveMode();
-    	}
-        if (!this.jobLogCaptured) {
-            // Try fetching.
-            try {
-                // Try fetching the log.
-                this.jobLogCaptured = this.FTPClient.retrieveFile(this.jobID, outputStream);
-                if (!this.jobLogCaptured) {
-                    this.jobCC = "RETR_ERR_JOB_NOT_FINISHED_OR_NOT_FOUND";
-                    return false;
-                }
-            } catch (IOException e) {
-                this.jobCC = "FETCH_LOG_IO_ERROR";
-                return false;
-            }
-        }
-        return this.obtainJobRC();
-    }
+	/**
+	 * @return Whether job RC was correctly obtained or not.
+	 */
+	private boolean obtainJobRC() {
+		this.jobCC = "COULD_NOT_RETRIEVE_JOB_RC";
+		// Verify connection.
+		if (!this.logon()) {
+			return false;
+		}
 
-    /**
-     * @return Whether job RC was correctly obtained or not.
-     */
-    private boolean obtainJobRC() {
-        this.jobCC = "COULD_NOT_RETRIEVE_JOB_RC";
-        // Verify connection.
-        if (!this.logon()) {
-            return false;
-        }
+		// JOB NAME
+		Pattern JOBNAME = Pattern.compile("(\\S+)\\s+" + jobID + "\\s+(.*)");
 
-        // JOB NAME
-        Pattern JOBNAME = Pattern.compile("(\\S+)\\s+" + jobID + "\\s+(.*)");
+		Pattern CC = Pattern.compile(".* RC=(\\S+) .*");
+		Pattern CCUndefined = Pattern.compile(".* RC\\s+(\\S+)\\s+.*");
+		Pattern ABEND = Pattern.compile(".* ABEND=(.*?) .*");
+		Pattern JCLERROR = Pattern.compile(".* \\(JCL error\\) .*");
 
-        Pattern CC = Pattern.compile(".* RC=(\\S+) .*");
-        Pattern CCUndefined = Pattern.compile(".* RC\\s+(\\S+)\\s+.*");
-        Pattern ABEND = Pattern.compile(".* ABEND=(.*?) .*");
-        Pattern JCLERROR = Pattern.compile(".* \\(JCL error\\) .*");
+		if (!this.FTPActiveMode) {
+			this.FTPClient.enterLocalPassiveMode();
+		}
+		// Check RC.
+		try {
+			for (FTPFile ftpFile : this.FTPClient.listFiles("*")) {
+				String fileName = ftpFile.toString();
 
-    	if (!this.FTPActiveMode) {
-    		this.FTPClient.enterLocalPassiveMode();
-    	}
-        // Check RC.
-        try {
-            for (FTPFile ftpFile : this.FTPClient.listFiles("*")) {
-                String fileName = ftpFile.toString();
+				Matcher JOBNAMEMatcher = JOBNAME.matcher(fileName);
+				if (JOBNAMEMatcher.matches()) {
+					this.jobName = JOBNAMEMatcher.group(1);
+					this.log("Found job " + this.jobID + " with name " + this.jobName + " in JES");
+					String rcPart = JOBNAMEMatcher.group(2);
+					this.log("Will check JOB status in '" + rcPart + "'");
+					if (this.JESINTERFACELEVEL1) {
+						if (rcPart.startsWith("INPUT")) {
+							this.log("Found job " + jobName + " in INPUT");
+							return false;
+						}
+						if (rcPart.startsWith("ACTIVE")) {
+							this.log("Found job " + jobName + " in ACTIVE");
+							return false;
+						}
+						if (rcPart.startsWith("OUTPUT")) {
+							this.log("Found job " + jobName + " in OUTPUT, will fetch log for additional scan");
+							Pattern HASP395 = Pattern
+									.compile(".*HASP395\\s+" + jobName + "\\s+ENDED(\\s+-\\s+(\\S+)\\s*)?.*");
+							// Try fetching the log.
+							ByteArrayOutputStream tempOutputStream = new ByteArrayOutputStream();
+							boolean gotHASP395 = false;
+							// If we see "JCL ERROR" line before HASP365 without actual RC - use JCL ERROR
+							boolean sawJCLError = false;
+							if (this.FTPClient.retrieveFile(this.jobID, tempOutputStream)) {
+								for (String line : tempOutputStream.toString(StandardCharsets.US_ASCII.name())
+										.split("\\n")) {
+									sawJCLError |= line.contains("JCL ERROR");
+									Matcher HASP395Matcher = HASP395.matcher(line);
+									if (HASP395Matcher.matches()) {
+										rcPart = HASP395Matcher.group(2);
+										if (rcPart == null) {
+											if (sawJCLError) {
+												this.jobCC = "JCL_ERROR";
+												return true;
+											}
+											this.err("Found HASP395 with no RC info: '" + line + "'");
+											return false;
+										}
+										this.log("Found HASP395: '" + rcPart + "'");
+										rcPart = "FROM_JOB_LOG " + rcPart + " FROM_JOB_LOG";
+										gotHASP395 = true;
+										break;
+									}
+								}
+							}
+							if (!gotHASP395) {
+								this.err("Failed to find HASP395 in job log");
+								return false;
+							}
+						}
+					}
+					// Here we either have rcPart in JESINTERFACELEVEL=2 format
+					Matcher JCLERRORMatcher = JCLERROR.matcher(rcPart);
+					if (JCLERRORMatcher.matches()) {
+						this.jobCC = "JCL_ERROR";
+						return true;
+					}
+					Matcher ABENDMatcher = ABEND.matcher(rcPart);
+					if (ABENDMatcher.matches()) {
+						this.jobCC = "ABEND_" + ABENDMatcher.group(1);
+						return true;
+					}
+					Matcher CCUndefinedMatcher = CCUndefined.matcher(rcPart);
+					if (CCUndefinedMatcher.matches()) {
+						this.jobCC = CCUndefinedMatcher.group(1).toUpperCase();
+						return true;
+					}
+					Matcher CCMatcher = CC.matcher(rcPart);
+					if (CCMatcher.matches()) {
+						this.jobCC = CCMatcher.group(1);
+						return true;
+					}
+					this.err("Unexpected rc part: '" + rcPart + "'");
 
-                Matcher JOBNAMEMatcher = JOBNAME.matcher(fileName);
-                if (JOBNAMEMatcher.matches()) {
-                    this.jobName = JOBNAMEMatcher.group(1);
-                    this.log("Found job " + this.jobID + " with name " + this.jobName + " in JES");
-                    String rcPart = JOBNAMEMatcher.group(2);
-                    this.log("Will check JOB status in '" + rcPart + "'");
-                    if (this.JESINTERFACELEVEL1) {
-                        if (rcPart.startsWith("INPUT")) {
-                            this.log("Found job " + jobName + " in INPUT");
-                            return false;
-                        }
-                        if (rcPart.startsWith("ACTIVE")) {
-                            this.log("Found job " + jobName + " in ACTIVE");
-                            return false;
-                        }
-                        if (rcPart.startsWith("OUTPUT")) {
-                            this.log("Found job " + jobName + " in OUTPUT, will fetch log for additional scan");
-                            Pattern HASP395 = Pattern.compile(".*HASP395\\s+" + jobName + "\\s+ENDED(\\s+-\\s+(\\S+)\\s*)?.*");
-                            // Try fetching the log.
-                            ByteArrayOutputStream tempOutputStream = new ByteArrayOutputStream();
-                            boolean gotHASP395 = false;
-                            // If we see "JCL ERROR" line before HASP365 without actual RC - use JCL ERROR
-                            boolean sawJCLError = false;
-                            if (this.FTPClient.retrieveFile(this.jobID, tempOutputStream)) {
-                                for (String line : tempOutputStream.toString(StandardCharsets.US_ASCII.name()).split("\\n")) {
-                                    sawJCLError |= line.contains("JCL ERROR");
-                                    Matcher HASP395Matcher = HASP395.matcher(line);
-                                    if (HASP395Matcher.matches()) {
-                                        rcPart = HASP395Matcher.group(2);
-                                        if (rcPart == null) {
-                                            if (sawJCLError) {
-                                                this.jobCC = "JCL_ERROR";
-                                                return true;
-                                            }
-                                            this.err("Found HASP395 with no RC info: '" + line + "'");
-                                            return false;
-                                        }
-                                        this.log("Found HASP395: '" + rcPart + "'");
-                                        rcPart = "FROM_JOB_LOG " + rcPart + " FROM_JOB_LOG";
-                                        gotHASP395 = true;
-                                        break;
-                                    }
-                                }
-                            }
-                            if (!gotHASP395) {
-                                this.err("Failed to find HASP395 in job log");
-                                return false;
-                            }
-                        }
-                    }
-                    // Here we either have rcPart in JESINTERFACELEVEL=2 format
-                    Matcher JCLERRORMatcher = JCLERROR.matcher(rcPart);
-                    if (JCLERRORMatcher.matches()) {
-                        this.jobCC = "JCL_ERROR";
-                        return true;
-                    }
-                    Matcher ABENDMatcher = ABEND.matcher(rcPart);
-                    if (ABENDMatcher.matches()) {
-                        this.jobCC = "ABEND_" + ABENDMatcher.group(1);
-                        return true;
-                    }
-                    Matcher CCUndefinedMatcher = CCUndefined.matcher(rcPart);
-                    if (CCUndefinedMatcher.matches()) {
-                        this.jobCC = CCUndefinedMatcher.group(1).toUpperCase();
-                        return true;
-                    }
-                    Matcher CCMatcher = CC.matcher(rcPart);
-                    if (CCMatcher.matches()) {
-                        this.jobCC = CCMatcher.group(1);
-                        return true;
-                    }
-                    this.err("Unexpected rc part: '" + rcPart + "'");
+					return false;
+				}
+			}
+		} catch (IOException ignored) {
+			// Do nothing.
+		}
+		return false;
+	}
 
-                    return false;
-                }
-            }
-        } catch (IOException ignored) {
-            // Do nothing.
-        }
-        return false;
-    }
+	/**
+	 * Delete job log from spool. Job is distinguished by previously obtained
+	 * <code>jobID</code>.
+	 *
+	 * @see ZFTPConnector#submit(InputStream, boolean, int, OutputStream, boolean)
+	 */
+	private void deleteJobLog() {
+		// Verify connection.
+		if (!this.logon()) {
+			return;
+		}
 
-    /**
-     * Delete job log from spool. Job is distinguished by previously obtained <code>jobID</code>.
-     *
-     * @see ZFTPConnector#submit(InputStream, boolean, int, OutputStream, boolean)
-     */
-    private void deleteJobLog() {
-        // Verify connection.
-        if (!this.logon()) {
-            return;
-        }
+		// Delete log.
+		if (!this.FTPActiveMode) {
+			this.FTPClient.enterLocalPassiveMode();
+		}
+		try {
+			this.log("Deleting joblog from spool");
+			this.FTPClient.deleteFile(this.jobID);
+			this.log("Done");
+		} catch (IOException e) {
+			// Do nothing.
+		}
+	}
 
-        // Delete log.
-    	if (!this.FTPActiveMode) {
-    		this.FTPClient.enterLocalPassiveMode();
-    	}
-        try {
-            this.FTPClient.deleteFile(this.jobID);
-        } catch (IOException e) {
-            // Do nothing.
-        }
-    }
+	/**
+	 * Get JobID.
+	 *
+	 * @return Current <b><code>jobID</code></b>.
+	 */
+	String getJobID() {
+		return this.jobID;
+	}
 
-    /**
-     * Get JobID.
-     *
-     * @return Current <b><code>jobID</code></b>.
-     */
-    String getJobID() {
-        return this.jobID;
-    }
+	/**
+	 * Get Jobname.
+	 *
+	 * @return Current <b><code>jobName</code></b>.
+	 */
+	String getJobName() {
+		return this.jobName;
+	}
 
-    /**
-     * Get Jobname.
-     *
-     * @return Current <b><code>jobName</code></b>.
-     */
-    String getJobName() {
-        return this.jobName;
-    }
+	/**
+	 * Get JobCC.
+	 *
+	 * @return Current <b><code>jobCC</code></b>.
+	 */
+	String getJobCC() {
+		return this.jobCC;
+	}
 
-    /**
-     * Get JobCC.
-     *
-     * @return Current <b><code>jobCC</code></b>.
-     */
-    String getJobCC() {
-        return this.jobCC;
-    }
+	/**
+	 * Log information into logger.info and listener logger
+	 *
+	 * @param text Text for logging.
+	 */
+	private void log(String text) {
+		logger.info(logPrefix + text);
+		System.out.println(text);
+		if (listener != null)
+			listener.getLogger().println(text);
+	}
 
-    /**
-     * Log information into logger.info and listener logger
-     *
-     * @param text Text for logging.
-     */
-    private void log(String text) {
-        logger.info(logPrefix + text);
-        System.out.println(text);
-        if (listener != null)
-            listener.getLogger().println(text);
-    }
-
-    /**
-     * Log information into logger.severe and listener error logger
-     *
-     * @param text Text for logging.
-     */
-    private void err(String text) {
-        logger.severe(logPrefix + text);
-        System.err.println(text);
-        if (listener != null)
-            listener.error(text);
-    }
+	/**
+	 * Log information into logger.severe and listener error logger
+	 *
+	 * @param text Text for logging.
+	 */
+	private void err(String text) {
+		logger.severe(logPrefix + text);
+		System.err.println(text);
+		if (listener != null)
+			listener.error(text);
+	}
 }

--- a/src/main/java/org/jenkinsci/plugins/IBM_zOS_Connector/ZOSJobSubmitter.java
+++ b/src/main/java/org/jenkinsci/plugins/IBM_zOS_Connector/ZOSJobSubmitter.java
@@ -28,466 +28,438 @@ import java.util.List;
 import java.util.logging.Logger;
 
 /**
- * <h1>ZOSJobSubmitter</h1>
- * Build step action for submitting JCL job.
+ * <h1>ZOSJobSubmitter</h1> Build step action for submitting JCL job.
  *
  * @author <a href="mailto:candiduslynx@gmail.com">Alexander Shcherbakov</a>
  * @version 1.0
  */
 public class ZOSJobSubmitter extends Builder implements SimpleBuildStep {
-    /**
-     * Simple logger.
-     */
-    private static final Logger logger = Logger.getLogger(ZOSJobSubmitter.class.getName());
-    /**
-     * LPAR name or IP address.
-     */
-    private String server;
-    /**
-     * FTP port for connection
-     */
-    private int port;
-    /**
-     * Credentials id to be converted to login+pw.
-     */
-    private String credentialsId;
-    /**
-     * Whether need to wait for the job completion.
-     */
-    private boolean wait;
-    /**
-     * Whether FTP server is in JESINTERFACELEVEL=1.
-     */
-    private boolean JESINTERFACELEVEL1;
-    /**
-     * Whether the job log is to be deleted upon job end.
-     */
-    private boolean deleteJobFromSpool;
-    /**
-     * Whether the job log is to be printed to Console.
-     */
-    private boolean jobLogToConsole;
-    /**
-     * Time to wait for the job to end. If set to <code>0</code> the buil will wait forever.
-     */
-    private int waitTime;
-    /**
-     * Path to local file with JCL text of the job to be submitted.
-     */
-    private String jobFile;
-    /**
-     * MaxCC to decide that job ended OK.
-     */
-    private String MaxCC;
-    /**
-     * FTP data transfer mode
-     */
-    private boolean FTPActiveMode;
+	/**
+	 * Simple logger.
+	 */
+	private static final Logger logger = Logger.getLogger(ZOSJobSubmitter.class.getName());
+	/**
+	 * LPAR name or IP address.
+	 */
+	private String server;
+	/**
+	 * FTP port for connection
+	 */
+	private int port;
+	/**
+	 * Credentials id to be converted to login+pw.
+	 */
+	private String credentialsId;
+	/**
+	 * Whether need to wait for the job completion.
+	 */
+	private boolean wait;
+	/**
+	 * Whether FTP server is in JESINTERFACELEVEL=1.
+	 */
+	private boolean JESINTERFACELEVEL1;
+	/**
+	 * Whether the job log is to be deleted upon job end.
+	 */
+	private boolean deleteJobFromSpool;
+	/**
+	 * Whether the job log is to be printed to Console.
+	 */
+	private boolean jobLogToConsole;
+	/**
+	 * Time to wait for the job to end. If set to <code>0</code> the buil will wait
+	 * forever.
+	 */
+	private int waitTime;
+	/**
+	 * Path to local file with JCL text of the job to be submitted.
+	 */
+	private String jobFile;
+	/**
+	 * MaxCC to decide that job ended OK.
+	 */
+	private String MaxCC;
+	/**
+	 * FTP data transfer mode
+	 */
+	private boolean FTPActiveMode;
+	/**
+	 * z/OS remote job flag
+	 */
+	private boolean isJobOnHost;
 
-    /**
-     * Constructor. Invoked when 'Apply' or 'Save' button is pressed on the project configuration page.
-     *
-     * @param MaxCC              Maximum allowed CC for job to be considered OK.
-     * @param server             LPAR name or IP address.
-     * @param port               FTP port to connect to.
-     * @param credentialsId      Credentials id..
-     * @param wait               Whether we need to wait for the job completion.
-     * @param waitTime           Maximum wait time. If set to <code>0</code> will wait forever.
-     * @param deleteJobFromSpool Whether the job log will be deleted from the spool after end.
-     * @param jobLogToConsole    Whether the job log will be printed to console.
-     * @param jobFile            File with JCL of the job to be submitted.
-     * @param JESINTERFACELEVEL1 Is FTP server configured for JESINTERFACELEVEL=1?
-     * @param FTPActiveMode      FTP data transfer mode (true=active, false=passive)       
-     */
-    @DataBoundConstructor
-    public ZOSJobSubmitter(
-            String server,
-            int port,
-            String credentialsId,
-            boolean wait,
-            int waitTime,
-            boolean deleteJobFromSpool,
-            boolean jobLogToConsole,
-            String jobFile,
-            String MaxCC,
-            boolean JESINTERFACELEVEL1,
-            boolean FTPActiveMode) {
-        // Copy values
-        this.server = server.replaceAll("\\s", "");
-        this.port = port;
-        this.credentialsId = credentialsId;
-        this.wait = wait;
-        this.waitTime = waitTime;
-        this.JESINTERFACELEVEL1 = JESINTERFACELEVEL1;
-        this.FTPActiveMode = FTPActiveMode;
-        this.deleteJobFromSpool = deleteJobFromSpool;
-        this.jobLogToConsole = jobLogToConsole;
-        this.jobFile = jobFile;
-        if (MaxCC == null || MaxCC.isEmpty()) {
-            this.MaxCC = "0000";
-        } else {
-            this.MaxCC = MaxCC;
-            if (this.MaxCC.length() < 4) {
-                this.MaxCC = "000".substring(0, 4 - this.MaxCC.length()) + this.MaxCC;
-            }
-        }
-    }
+	/**
+	 * Constructor. Invoked when 'Apply' or 'Save' button is pressed on the project
+	 * configuration page.
+	 *
+	 * @param MaxCC              Maximum allowed CC for job to be considered OK.
+	 * @param server             LPAR name or IP address.
+	 * @param port               FTP port to connect to.
+	 * @param credentialsId      Credentials id..
+	 * @param wait               Whether we need to wait for the job completion.
+	 * @param waitTime           Maximum wait time. If set to <code>0</code> will
+	 *                           wait forever.
+	 * @param deleteJobFromSpool Whether the job log will be deleted from the spool
+	 *                           after end.
+	 * @param jobLogToConsole    Whether the job log will be printed to console.
+	 * @param jobFile            File with JCL of the job to be submitted.
+	 * @param JESINTERFACELEVEL1 Is FTP server configured for JESINTERFACELEVEL=1?
+	 * @param FTPActiveMode      FTP data transfer mode (true=active, false=passive)
+	 * @param isJobOnHost        Is job file on host or local system
+	 */
+	@DataBoundConstructor
+	public ZOSJobSubmitter(String server, int port, String credentialsId, boolean wait, int waitTime,
+			boolean deleteJobFromSpool, boolean jobLogToConsole, String jobFile, String MaxCC,
+			boolean JESINTERFACELEVEL1, boolean FTPActiveMode, boolean isJobOnHost) {
+		// Copy values
+		this.server = server.replaceAll("\\s", "");
+		this.port = port;
+		this.credentialsId = credentialsId;
+		this.wait = wait;
+		this.waitTime = waitTime;
+		this.JESINTERFACELEVEL1 = JESINTERFACELEVEL1;
+		this.FTPActiveMode = FTPActiveMode;
+		this.isJobOnHost = isJobOnHost;
+		this.deleteJobFromSpool = deleteJobFromSpool;
+		this.jobLogToConsole = jobLogToConsole;
+		this.jobFile = jobFile;
+		if (MaxCC == null || MaxCC.isEmpty()) {
+			this.MaxCC = "0000";
+		} else {
+			this.MaxCC = MaxCC;
+			if (this.MaxCC.length() < 4) {
+				this.MaxCC = "000".substring(0, 4 - this.MaxCC.length()) + this.MaxCC;
+			}
+		}
+	}
 
-    /**
-     * Submit the job for execution.
-     *
-     * @param run       Current run
-     * @param workspace Current workspace
-     * @param launcher  Current launcher
-     * @param listener  Current listener
-     *                  <p>
-     *                  <br> Always <code>true</code> if <b><code>wait</code></b> is <code>false</code>.
-     * @see ZFTPConnector
-     */
-    @Override
-    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
-            throws IOException {
-        // variables to be expanded
-        String _server = this.server;
-        String _jobFile = this.jobFile;
-        String _MaxCC = this.MaxCC;
-        String inputJCL;
+	/**
+	 * Submit the job for execution.
+	 *
+	 * @param run       Current run
+	 * @param workspace Current workspace
+	 * @param launcher  Current launcher
+	 * @param listener  Current listener
+	 *                  <p>
+	 *                  <br>
+	 *                  Always <code>true</code> if <b><code>wait</code></b> is
+	 *                  <code>false</code>.
+	 * @see ZFTPConnector
+	 */
+	@Override
+	public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
+			@Nonnull TaskListener listener) throws IOException {
+		// variables to be expanded
+		String _server = this.server;
+		String _jobFile = this.jobFile;
+		String _MaxCC = this.MaxCC;
+		String inputJCL = "";
 
-        String logPrefix = run.getParent().getDisplayName() + " " + run.getId() + ": ";
-        try {
-            logger.info(logPrefix + "will expand variables");
-            EnvVars environment = run.getEnvironment(listener);
-            _server = environment.expand(_server);
-            _jobFile = environment.expand(_jobFile);
-            _MaxCC = environment.expand(_MaxCC);
-            // Read the JCL + expand.
-            try {
-                inputJCL = workspace.child(_jobFile).readToString();
-            } catch (FileNotFoundException e) {
-                throw new AbortException("Job file not found: ./" + _jobFile);
-            }
-            inputJCL = environment.expand(inputJCL);
+		String logPrefix = run.getParent().getDisplayName() + " " + run.getId() + ": ";
+		try {
+			logger.info(logPrefix + "will expand variables");
+			EnvVars environment = run.getEnvironment(listener);
+			_server = environment.expand(_server);
+			_jobFile = environment.expand(_jobFile);
+			_MaxCC = environment.expand(_MaxCC);
+			// Read the JCL + expand (for local job only)
+			if (!isJobOnHost) {
+				try {
+					inputJCL = workspace.child(_jobFile).readToString();
+				} catch (FileNotFoundException e) {
+					throw new AbortException("Job file not found: ./" + _jobFile);
+				}
+				inputJCL = environment.expand(inputJCL);
+			}
 
-        } catch (IOException | InterruptedException e) {
-            e.printStackTrace();
-            throw new AbortException(e.getMessage());
-        }
+		} catch (IOException | InterruptedException e) {
+			e.printStackTrace();
+			throw new AbortException(e.getMessage());
+		}
 
-        // Get login + pw.
-        DomainRequirement domain = new DomainRequirement();
-        StandardUsernamePasswordCredentials creds = CredentialsProvider.findCredentialById(credentialsId,
-                StandardUsernamePasswordCredentials.class,
-                run, domain);
-        if (creds == null) {
-            throw new AbortException("Cannot resolve credentials: " + credentialsId);
-        }
+		// Get login + pw.
+		DomainRequirement domain = new DomainRequirement();
+		StandardUsernamePasswordCredentials creds = CredentialsProvider.findCredentialById(credentialsId,
+				StandardUsernamePasswordCredentials.class, run, domain);
+		if (creds == null) {
+			throw new AbortException("Cannot resolve credentials: " + credentialsId);
+		}
 
-        // Prepare the input and output stream.
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(inputJCL.getBytes(StandardCharsets.UTF_8));
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		// Prepare the input and output stream.
+		ByteArrayInputStream inputStream = new ByteArrayInputStream(inputJCL.getBytes(StandardCharsets.UTF_8));
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        // Get connector.
-        ZFTPConnector zFTPConnector = new ZFTPConnector(_server,
-                this.port,
-                creds.getUsername(),
-                creds.getPassword().getPlainText(),
-                this.JESINTERFACELEVEL1,
-                logPrefix,
-                this.FTPActiveMode);
-        // Submit the job.
-        boolean result = zFTPConnector.submit(inputStream, this.wait, this.waitTime, outputStream, this.deleteJobFromSpool, listener);
+		// Get connector.
+		ZFTPConnector zFTPConnector = new ZFTPConnector(_server, this.port, creds.getUsername(),
+				creds.getPassword().getPlainText(), this.JESINTERFACELEVEL1, logPrefix, this.FTPActiveMode);
+		// Submit the job.
+		boolean result = zFTPConnector.submit(_jobFile, inputStream, this.wait, this.waitTime, outputStream,
+				this.deleteJobFromSpool, listener, this.isJobOnHost);
 
-        // Get CC.
-        String printableCC = zFTPConnector.getJobCC();
-        if (printableCC != null)
-            printableCC = printableCC.replaceAll("\\s+", "");
-        else
-            printableCC = "";
+		// Get CC.
+		String printableCC = zFTPConnector.getJobCC();
+		if (printableCC != null)
+			printableCC = printableCC.replaceAll("\\s+", "");
+		else
+			printableCC = "";
 
-        // Print the info about the job
-        logger.info("Job [" + zFTPConnector.getJobID() + "] processing finished.");
-        StringBuilder reportBuilder = new StringBuilder();
-        reportBuilder.append("Job [")
-                .append(zFTPConnector.getJobID())
-                .append("] processing ");
-        if (this.wait) {
-            if (!printableCC.matches("\\d+")) {
-                if (printableCC.startsWith("ABEND")) {
-                    reportBuilder.append("ABnormally ENDed. ABEND code = [");
-                } else {
-                    reportBuilder.append("failed. Reason: [");
-                }
-            } else {
-                reportBuilder.append("finished. Captured RC = [");
-            }
-            reportBuilder
-                    .append(printableCC)
-                    .append("]");
-        } else {
-            reportBuilder.append("finished. Skip waiting.");
-        }
-        listener.getLogger().println(reportBuilder.toString());
+		// Print the info about the job
+		logger.info("Job [" + zFTPConnector.getJobID() + "] processing finished.");
+		StringBuilder reportBuilder = new StringBuilder();
+		reportBuilder.append("Job [").append(zFTPConnector.getJobID()).append("] processing ");
+		if (this.wait) {
+			if (!printableCC.matches("\\d+")) {
+				if (printableCC.startsWith("ABEND")) {
+					reportBuilder.append("ABnormally ENDed. ABEND code = [");
+				} else {
+					reportBuilder.append("failed. Reason: [");
+				}
+			} else {
+				reportBuilder.append("finished. Captured RC = [");
+			}
+			reportBuilder.append(printableCC).append("]");
+		} else {
+			reportBuilder.append("finished. Skip waiting.");
+		}
+		listener.getLogger().println(reportBuilder.toString());
 
-        // If wait was requested try to save the job log.
-        if (this.wait) {
-            if (this.jobLogToConsole) {
-                listener.getLogger().println(outputStream.toString(StandardCharsets.US_ASCII.name()));
-            }
-            // Save the log.
-            try {
-                FilePath savedOutput = new FilePath(workspace,
-                        String.format("%s [%s] (%s - %s) %s - %s.log",
-                                zFTPConnector.getJobName(),
-                                printableCC,
-                                _server,
-                                zFTPConnector.getJobID(),
-                                run.getParent().getDisplayName(),
-                                run.getId()
-                        ));
-                outputStream.writeTo(savedOutput.write());
-                outputStream.close();
-            } catch (IOException | InterruptedException e) {
-                e.printStackTrace();
-                throw new AbortException(e.getMessage());
-            }
-        } else {
-            printableCC = "0000"; //set RC = 0
-        }
+		// If wait was requested try to save the job log.
+		if (this.wait) {
+			if (this.jobLogToConsole) {
+				listener.getLogger().println(outputStream.toString(StandardCharsets.US_ASCII.name()));
+			}
+			// Save the log.
+			try {
+				FilePath savedOutput = new FilePath(workspace,
+						String.format("%s [%s] (%s - %s) %s - %s.log", zFTPConnector.getJobName(), printableCC, _server,
+								zFTPConnector.getJobID(), run.getParent().getDisplayName(), run.getId()));
+				outputStream.writeTo(savedOutput.write());
+				outputStream.close();
+			} catch (IOException | InterruptedException e) {
+				e.printStackTrace();
+				throw new AbortException(e.getMessage());
+			}
+		} else {
+			printableCC = "0000"; // set RC = 0
+		}
 
-        if (!(result && (_MaxCC.compareTo(printableCC) >= 0))) {
-            throw new AbortException("z/OS job failed with CC " + printableCC);
-        }
-    }
+		if (!(result && (_MaxCC.compareTo(printableCC) >= 0))) {
+			throw new AbortException("z/OS job failed with CC " + printableCC);
+		}
+	}
 
-    /**
-     * Get LPAR name of IP address.
-     *
-     * @return <b><code>server</code></b>
-     */
-    public String getServer() {
-        return this.server;
-    }
+	/**
+	 * Get LPAR name of IP address.
+	 *
+	 * @return <b><code>server</code></b>
+	 */
+	public String getServer() {
+		return this.server;
+	}
 
-    /**
-     * Get FTP port to connect to.
-     *
-     * @return <b><code>port</code></b>
-     */
-    public int getPort() {
-        return this.port;
-    }
+	/**
+	 * Get FTP port to connect to.
+	 *
+	 * @return <b><code>port</code></b>
+	 */
+	public int getPort() {
+		return this.port;
+	}
 
-    /**
-     * @return credentials id provided.
-     */
-    public String getCredentialsId() {
-        return credentialsId;
-    }
+	/**
+	 * @return credentials id provided.
+	 */
+	public String getCredentialsId() {
+		return credentialsId;
+	}
 
-    /**
-     * @return job file provided.
-     */
-    public String getJobFile() {
-        return jobFile;
-    }
+	/**
+	 * @return job file provided.
+	 */
+	public String getJobFile() {
+		return jobFile;
+	}
 
-    /**
-     * Get wait.
-     *
-     * @return <b><code>wait</code></b>
-     */
-    public boolean getWait() {
-        return this.wait;
-    }
+	/**
+	 * Get wait.
+	 *
+	 * @return <b><code>wait</code></b>
+	 */
+	public boolean getWait() {
+		return this.wait;
+	}
 
-    /**
-     * Get JESINTERFACELEVEL1.
-     *
-     * @return <b><code>JESINTERFACELEVEL1</code></b>
-     */
-    public boolean getJESINTERFACELEVEL1() {
-        return this.JESINTERFACELEVEL1;
-    }
+	/**
+	 * Get JESINTERFACELEVEL1.
+	 *
+	 * @return <b><code>JESINTERFACELEVEL1</code></b>
+	 */
+	public boolean getJESINTERFACELEVEL1() {
+		return this.JESINTERFACELEVEL1;
+	}
 
-    /**
-     * Get deleteJobFromSpool.
-     *
-     * @return <b><code>deleteJobFromSpool</code></b>
-     */
-    public boolean getDeleteJobFromSpool() {
-        return this.deleteJobFromSpool;
-    }
+	/**
+	 * Get deleteJobFromSpool.
+	 *
+	 * @return <b><code>deleteJobFromSpool</code></b>
+	 */
+	public boolean getDeleteJobFromSpool() {
+		return this.deleteJobFromSpool;
+	}
 
-    /**
-     * Get jobLogToConsole.
-     *
-     * @return <b><code>jobLogToConsole</code></b>
-     */
-    public boolean getJobLogToConsole() {
-        return this.jobLogToConsole;
-    }
+	/**
+	 * Get jobLogToConsole.
+	 *
+	 * @return <b><code>jobLogToConsole</code></b>
+	 */
+	public boolean getJobLogToConsole() {
+		return this.jobLogToConsole;
+	}
 
-    /**
-     * Get wait time.
-     *
-     * @return <b><code>waitTime</code></b>
-     */
-    public int getWaitTime() {
-        return this.waitTime;
-    }
+	/**
+	 * Get wait time.
+	 *
+	 * @return <b><code>waitTime</code></b>
+	 */
+	public int getWaitTime() {
+		return this.waitTime;
+	}
 
+	/**
+	 * @return <b><code>MaxCC of the job to be considered OK</code></b>
+	 */
+	public String getMaxCC() {
+		return this.MaxCC;
+	}
 
-    /**
-     * @return <b><code>MaxCC of the job to be considered OK</code></b>
-     */
-    public String getMaxCC() {
-        return this.MaxCC;
-    }
-    
-    /**
-     * Get FTPActiveMode
-     *
-     * @return <b><code>FTPActiveMode</code></b>
-     */
-    public boolean getFTPActiveMode() {
-        return this.FTPActiveMode;
-    }
+	/**
+	 * Get FTPActiveMode
+	 *
+	 * @return <b><code>FTPActiveMode</code></b>
+	 */
+	public boolean getFTPActiveMode() {
+		return this.FTPActiveMode;
+	}
 
-    /**
-     * Get descriptor for this class.
-     *
-     * @return descriptor for this class.
-     */
-    @Override
-    public ZOSJobSubmitterDescriptor getDescriptor() {
-        return (ZOSJobSubmitterDescriptor) super.getDescriptor();
-    }
+	/**
+	 * Get descriptor for this class.
+	 *
+	 * @return descriptor for this class.
+	 */
+	@Override
+	public ZOSJobSubmitterDescriptor getDescriptor() {
+		return (ZOSJobSubmitterDescriptor) super.getDescriptor();
+	}
 
-    /**
-     * <h1>zOSJobSubmitterDescriptor</h1>
-     * Descriptor for ZOSJobSubmitter.
-     *
-     * @author Alexander Shchrbakov (candiduslynx@gmail.com)
-     * @version 1.0
-     */
-    @Extension
-    public static final class ZOSJobSubmitterDescriptor extends BuildStepDescriptor<Builder> {
-        /**
-         * Primitive constructor.
-         */
-        public ZOSJobSubmitterDescriptor() {
-            load();
-        }
+	/**
+	 * <h1>zOSJobSubmitterDescriptor</h1> Descriptor for ZOSJobSubmitter.
+	 *
+	 * @author Alexander Shcherbakov (candiduslynx@gmail.com)
+	 * @version 1.0
+	 */
+	@Extension
+	public static final class ZOSJobSubmitterDescriptor extends BuildStepDescriptor<Builder> {
+		/**
+		 * Primitive constructor.
+		 */
+		public ZOSJobSubmitterDescriptor() {
+			load();
+		}
 
-        /**
-         * Function for validation of 'Server' field on project configuration page
-         *
-         * @param value Current server.
-         * @return Whether server name looks OK.
-         */
-        public FormValidation doCheckServer(@QueryParameter String value) {
-            if (value.length() == 0)
-                return FormValidation.error("Please set a server");
-            return FormValidation.ok();
-        }
+		/**
+		 * Function for validation of 'Server' field on project configuration page
+		 *
+		 * @param value Current server.
+		 * @return Whether server name looks OK.
+		 */
+		public FormValidation doCheckServer(@QueryParameter String value) {
+			if (value.length() == 0)
+				return FormValidation.error("Please set a server");
+			return FormValidation.ok();
+		}
 
+		public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item item, @QueryParameter String credentialsId) {
+			ListBoxModel creds = PermissionsChecker.FillBasicCredentials(item, credentialsId);
+			if (creds != null) {
+				return creds;
+			}
+			return new StandardListBoxModel().includeMatchingAs(
+					item instanceof Queue.Task ? Tasks.getAuthenticationOf((Queue.Task) item) : ACL.SYSTEM, item,
+					StandardUsernamePasswordCredentials.class, Collections.emptyList(),
+					CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class));
 
-        public ListBoxModel doFillCredentialsIdItems(
-                @AncestorInPath Item item,
-                @QueryParameter String credentialsId) {
-            ListBoxModel creds = PermissionsChecker.FillBasicCredentials(item, credentialsId);
-            if (creds != null) {
-                return creds;
-            }
-            return new StandardListBoxModel()
-                    .includeMatchingAs(
-                            item instanceof Queue.Task
-                                    ? Tasks.getAuthenticationOf((Queue.Task) item)
-                                    : ACL.SYSTEM,
-                            item,
-                            StandardUsernamePasswordCredentials.class,
-                            Collections.emptyList(),
-                            CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class));
+		}
 
-        }
+		/**
+		 * @param item  configuration entity to use permissions from.
+		 * @param value Current credentials (or expression/env variable).
+		 * @return Whether creds are OK. Currently just check that it's set.
+		 */
+		public FormValidation doCheckCredentialsId(@AncestorInPath Item item, @QueryParameter String value) {
+			FormValidation resp = PermissionsChecker.CheckCredentialsID(item, value);
+			if (resp != null) {
+				return resp;
+			}
+			List<DomainRequirement> domainRequirements = new ArrayList<>();
+			if (CredentialsProvider.listCredentials(StandardUsernamePasswordCredentials.class, item,
+					item instanceof Queue.Task ? Tasks.getAuthenticationOf((Queue.Task) item) : ACL.SYSTEM,
+					domainRequirements, CredentialsMatchers.withId(value)).isEmpty()) {
+				return FormValidation.error("Cannot find currently selected credentials");
+			}
+			return FormValidation.ok();
+		}
 
+		/**
+		 * Function for validation of 'Job file' field on project configuration page
+		 *
+		 * @param value Current job file.
+		 * @return Whether job looks OK.
+		 */
+		public FormValidation doCheckJobFIle(@QueryParameter String value) {
+			if (value.length() == 0)
+				return FormValidation.error("Please set an input");
+			return FormValidation.ok();
+		}
 
-        /**
-         * @param item  configuration entity to use permissions from.
-         * @param value Current credentials (or expression/env variable).
-         * @return Whether creds are OK. Currently just check that it's set.
-         */
-        public FormValidation doCheckCredentialsId(
-                @AncestorInPath Item item,
-                @QueryParameter String value) {
-            FormValidation resp = PermissionsChecker.CheckCredentialsID(item, value);
-            if (resp != null) {
-                return resp;
-            }
-            List<DomainRequirement> domainRequirements = new ArrayList<>();
-            if (CredentialsProvider.listCredentials(
-                    StandardUsernamePasswordCredentials.class,
-                    item,
-                    item instanceof Queue.Task
-                            ? Tasks.getAuthenticationOf((Queue.Task) item)
-                            : ACL.SYSTEM, domainRequirements,
-                    CredentialsMatchers.withId(value)).isEmpty()) {
-                return FormValidation.error("Cannot find currently selected credentials");
-            }
-            return FormValidation.ok();
-        }
+		/**
+		 * Function for validation of 'Wait Time' field on project configuration page
+		 *
+		 * @param value Current wait time.
+		 * @return Whether wait time looks OK.
+		 */
+		public FormValidation doCheckWaitTime(@QueryParameter String value) {
+			if (!value.matches("\\d*"))
+				return FormValidation.error("Value must be numeric");
+			if (Integer.parseInt(value) < 0)
+				return FormValidation.error("Value must not be negative");
+			return FormValidation.ok();
+		}
 
-        /**
-         * Function for validation of 'Job file' field on project configuration page
-         *
-         * @param value Current job file.
-         * @return Whether job looks OK.
-         */
-        public FormValidation doCheckJobFIle(@QueryParameter String value) {
-            if (value.length() == 0)
-                return FormValidation.error("Please set an input");
-            return FormValidation.ok();
-        }
+		public FormValidation doCheckMaxCC(@QueryParameter String value) {
+			if (!value.matches("(\\d{1,4})|(\\s*)"))
+				return FormValidation.error("Value must be 4 decimal digits or empty");
+			return FormValidation.ok();
 
-        /**
-         * Function for validation of 'Wait Time' field on project configuration page
-         *
-         * @param value Current wait time.
-         * @return Whether wait time looks OK.
-         */
-        public FormValidation doCheckWaitTime(@QueryParameter String value) {
-            if (!value.matches("\\d*"))
-                return FormValidation.error("Value must be numeric");
-            if (Integer.parseInt(value) < 0)
-                return FormValidation.error("Value must not be negative");
-            return FormValidation.ok();
-        }
+		}
 
-        public FormValidation doCheckMaxCC(@QueryParameter String value) {
-            if (!value.matches("(\\d{1,4})|(\\s*)"))
-                return FormValidation.error("Value must be 4 decimal digits or empty");
-            return FormValidation.ok();
+		/**
+		 * If this build step can be used with the project.
+		 *
+		 * @param aClass Project description class.
+		 * @return Always <code>true</code>.
+		 */
+		public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+			// Indicates that this builder can be used with all kinds of project types
+			return true;
+		}
 
-        }
-
-        /**
-         * If this build step can be used with the project.
-         *
-         * @param aClass Project description class.
-         * @return Always <code>true</code>.
-         */
-        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
-            // Indicates that this builder can be used with all kinds of project types
-            return true;
-        }
-
-        /**
-         * Get printable name.
-         *
-         * @return Printable name for project configuration page.
-         */
-        public String getDisplayName() {
-            return "Submit z/OS job";
-        }
-    }
+		/**
+		 * Get printable name.
+		 *
+		 * @return Printable name for project configuration page.
+		 */
+		public String getDisplayName() {
+			return "Submit z/OS job";
+		}
+	}
 }

--- a/src/main/resources/org/jenkinsci/plugins/IBM_zOS_Connector/ZOSJobSubmitter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/IBM_zOS_Connector/ZOSJobSubmitter/config.jelly
@@ -12,6 +12,10 @@
     <f:entry field="jobFile" title="Job file">
         <f:textbox value="${it.getJobFile()}"/>
     </f:entry>
+    <f:entry field="isJobOnHost" title="isJobOnHost" 
+			 description="Submit job from z/OS dataset">
+        <f:checkbox default="false" value="${it.getIsJobOnHost()}"/>
+    </f:entry>
     <f:block>
         <table style="width:100%">
             <f:optionalBlock inline="true" field="wait" title="Wait for completion?" checked="${it.getWait()}">


### PR DESCRIPTION
Added option to submit job residing in z/OS dataset (disabled by default). 
If option is enabled value of 'Job file' field should be in format : '<z/OS library name>(member_name)' with or without single quotes. 
Also in this mode processing of options 'Delete job log from Spool?' and 'Print joblog to Console output?' is performed constantly regardless of flag 'Wait for completion?' value - this is because waiting for job completion is implicitly in power for all remote jobs.