### PR TITLE
Bump org.jenkins-ci.plugins:credentials from 1309.v8835d63eb_d8a_ to 1319.v7eb_51b_3a_c97b_

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>1309.v8835d63eb_d8a_</version>
+            <version>1319.v7eb_51b_3a_c97b_</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
 
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.version>2.387.1</jenkins.version>
+        <jenkins.version>2.387.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.76</version>
+        <version>4.77</version>
         <relativePath />
     </parent>
     <artifactId>zos-connector</artifactId>


### PR DESCRIPTION
Redo of https://github.com/jenkinsci/zos-connector-plugin/pull/72