### PR TITLE
Migrate from Commons Lang to native Java Platform functionality

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/IBM_zOS_Connector/PermissionsChecker.java
+++ b/src/main/java/org/jenkinsci/plugins/IBM_zOS_Connector/PermissionsChecker.java
@@ -2,11 +2,11 @@ package org.jenkinsci.plugins.IBM_zOS_Connector;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import hudson.Util;
 import hudson.model.Item;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -24,7 +24,7 @@ class PermissionsChecker {
                 return FormValidation.ok();
             }
         }
-        if (StringUtils.isBlank(value)) {
+        if (Util.fixEmptyAndTrim(value) == null) {
             return FormValidation.ok();
         }
         if (value.startsWith("${") && value.endsWith("}")) {


### PR DESCRIPTION
No need to depend on a third-party library here when the Java Platform provides this functionality natively.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

`StringUtils.isEmpty(x)` becomes `Util.fixEmpty(x) == null`, using the `hudson.Util` helper.

### Testing done

`mvn -B -ntp clean verify` on Java 21 / macOS. The build fails on a pre-existing SpotBugs finding
(`PA_PUBLIC_PRIMITIVE_ATTRIBUTE` in `LogSet`, a file this PR does not touch) — unmodified `master` fails
with exactly the same single finding.
The `ban-commons-lang-2` enforcer rule was left disabled because it needs parent POM
`6.2116.v7501b_67dc517` or newer; bumping the parent from `4.88` was out of scope here.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
